### PR TITLE
Add searchExact and searchPrecise support to game filters

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -159,6 +159,18 @@ func (filter *GamesFilter) WithoutGameSeries() *GamesFilter {
 	return filter
 }
 
+// WithSearchExact sets "search_exact" parameter
+func (filter *GamesFilter) WithSearchExact() *GamesFilter {
+	filter.searchExact = true
+	return filter
+}
+
+// WithSearchPrecise sets "search_precise" parameter
+func (filter *GamesFilter) WithSearchPrecise() *GamesFilter {
+	filter.searchPrecise = true
+	return filter
+}
+
 // SetOrdering sets results ordering
 func (filter *GamesFilter) SetOrdering(ordering string) *GamesFilter {
 	filter.ordering = ordering

--- a/filters_test.go
+++ b/filters_test.go
@@ -44,7 +44,9 @@ func TestNewGamesFilter(t *testing.T) {
 		WithoutParents().
 		WithoutGameSeries().
 		SetOrdering("-name").
-		SetMetacritic(20, 80)
+		SetMetacritic(20, 80).
+		WithSearchExact().
+		WithSearchPrecise()
 
 	assert.Equal(t, map[string]interface{}{
 		"creators":            "28,mike-morasky",
@@ -54,6 +56,8 @@ func TestNewGamesFilter(t *testing.T) {
 		"exclude_collection":  123,
 		"exclude_game_series": true,
 		"exclude_parents":     true,
+		"search_exact":        true,
+		"search_precise":      true,
 		"genres":              "9,action,indie",
 		"ordering":            "-name",
 		"page":                1,


### PR DESCRIPTION
At the moment the `searchExact` and `searchPrecise` fields cannot be set for a game filter since they do not have setters methods. 